### PR TITLE
Fix truffle-config detect

### DIFF
--- a/src/analysis/mythx/index.ts
+++ b/src/analysis/mythx/index.ts
@@ -360,7 +360,6 @@ export async function mythxAnalyze(progress) {
             log: console.log,
             warn: console.log,
         },
-        working_directory: pathInfo.rootDir,
     };
 
     let config: any;


### PR DESCRIPTION
On truffle project without migration folder `working_directory` is referencing to a folder with contracts. `Config.detect` wouldn't fix `working_directory`and contracts would be searched in non-existent folder `contracts/contracts`